### PR TITLE
Fix/error handling macos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .venv/
 .env
+.envrc

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # Introduction
 A simple streamlit application to capture and convert image using laptop camera.
 
+## Launch
+As per usual with streamlit
+
+```sh
+streamlit run app.py
+```
+
+
 ## Setup
 Make sure you have a .env file with the following keys
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ As per usual with streamlit
 streamlit run app.py
 ```
 
+Or debug mode
+```sh
+streamlit run app.py --logger.level=debug
+```
+
 
 ## Setup
 Make sure you have a .env file with the following keys

--- a/app.py
+++ b/app.py
@@ -10,7 +10,8 @@ st.set_page_config(layout="wide")
 class ImageConverter:
     def __init__(self, model_id="timbrooks/instruct-pix2pix"):
         self.pipe = StableDiffusionInstructPix2PixPipeline.from_pretrained(model_id, safety_checker=None)
-        self.pipe.to("cpu")
+        self.pipe.to("mps")
+        self.pipe.enable_attention_slicing()
         self.pipe.scheduler = EulerAncestralDiscreteScheduler.from_config(self.pipe.scheduler.config)
         
     def convert(self, prompt, original_image):

--- a/app.py
+++ b/app.py
@@ -14,6 +14,9 @@ class ImageConverter:
         self.pipe.scheduler = EulerAncestralDiscreteScheduler.from_config(self.pipe.scheduler.config)
         
     def convert(self, prompt, original_image):
+        if not original_image:
+            st.error("Click 'Take Photo' and wait for it to load before trying the image generation options")
+            return
         image = PIL.Image.open(original_image)
         image = image.resize((352, 626))
         image = PIL.ImageOps.exif_transpose(image)
@@ -54,7 +57,8 @@ class App:
         for option in options:
             if col2.button(option):
                 converted_image = self.image_converter.convert(f"Convert the image to a {option}", st.session_state.original_image)
-                col3.image(converted_image)
+                if converted_image:
+                    col3.image(converted_image)
         st.session_state.original_image = col1.camera_input("Take a photo",label_visibility="hidden")
         
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -17,13 +17,12 @@ class ImageConverter:
         if not original_image:
             st.error("Click 'Take Photo' and wait for it to load before trying the image generation options")
             return
-        image = PIL.Image.open(original_image)
-        image = image.resize((352, 626))
-        image = PIL.ImageOps.exif_transpose(image)
-        image = image.convert("RGB")
-        
-        converted_images = self.pipe(prompt, image=image, num_inference_steps=10, image_guidance_scale=1).images
-        return converted_images[0]
+        with PIL.Image.open(original_image) as image:
+            st.error(f"image size is {image.size}")
+            # image = PIL.ImageOps.exif_transpose(image) #this seems silly, are we rotating the laptop then wanting to reorient?
+            image = image.convert("RGB")
+            converted_images = self.pipe(prompt, image=image, num_inference_steps=10, image_guidance_scale=1).images
+            return converted_images[0]
 
 class App:
     def __init__(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ torch
 diffusers[torch]
 transformers
 streamlit-camera-input-live
+watchdog


### PR DESCRIPTION
This PR makes the app faster, removes unhelpful verbose errors like `NoneType has no ...something...attribute` (specifically when you forget to click "take photo", or if you are impatient as I am and don't wait for it to be captured before trying to run the diffusion on it.) and drops the weird image re-sizing (landscape squished to portrait - why? Maybe to compensate for something a windows webcam was doing, or maybe for a funpark effect?). The Macbook camera photos were being captured at a pretty reasonable size anyway, to something like 540 x 400. TIL: I logged the `image.size` and noticed it varied around this number slightly - maybe macbook camera is doing some of it's own thumbnailing FTW.

Note that these changes are specific to Mac silicon, and assume it will be run from the laptop's webcam. The re-orientation part I removed might have been useful if you are uploading photos from a camera that were taken upside down or something, but not relevant for this use case. 

Commits:
* Add error handling when no image is captured
* Use context manager for files and remove unecessary image preprocessing
* Add macbook pro silicon optimisations see https://huggingface.co/docs/diffusers/optimization/mps

Minor commits:
* Ignore direnv's dotfile
* Add helpful streamlit launch tip
* Add watchdog library as per streamlit nags

